### PR TITLE
Fix tests for feature, Bump Version, API fix

### DIFF
--- a/msdfgen/Cargo.toml
+++ b/msdfgen/Cargo.toml
@@ -65,6 +65,7 @@ version = "^0.1"
 [features]
 all = ["ttf-parser", "font", "freetype-rs", "png"]
 rustdoc = ["msdfgen-sys/rustdoc", "all"]
+default = ["all"]
 
 [package.metadata.docs.rs]
 features = ["rustdoc"]

--- a/msdfgen/Cargo.toml
+++ b/msdfgen/Cargo.toml
@@ -39,7 +39,7 @@ version = "^0.6"
 optional = true
 
 [dependencies.freetype-rs]
-version = "^0.23"
+version = "^0.26"
 optional = true
 
 [dependencies.png]

--- a/msdfgen/src/interop/freetype_rs.rs
+++ b/msdfgen/src/interop/freetype_rs.rs
@@ -2,10 +2,10 @@ use freetype;
 use crate::{Shape, EdgeHolder, EdgeColor, Point2, FontExt};
 
 impl FontExt for freetype::face::Face {
-    type Glyph = usize;
+    type Glyph = u32;
 
     fn glyph_shape(&self, glyph: Self::Glyph) -> Option<Shape> {
-        self.load_char(glyph, freetype::face::LoadFlag::NO_SCALE).ok()?;
+        self.load_glyph(glyph, freetype::face::LoadFlag::NO_SCALE).ok()?;
         let glyph = self.glyph();
         let outline = glyph.outline()?;
 

--- a/msdfgen/src/lib.rs
+++ b/msdfgen/src/lib.rs
@@ -97,6 +97,8 @@ pub use self::interop::*;
 // or: cargo test --features "all" etc.
 #[cfg(test)]
 #[allow(dead_code)]
+#[allow(unused_imports)]
+#[allow(unused_variables)]
 mod test {
     use std::fs::File;
     #[cfg(feature = "ttf-parser")]

--- a/msdfgen/src/lib.rs
+++ b/msdfgen/src/lib.rs
@@ -17,7 +17,7 @@
 
 ## Usage
 
-```no_run
+```ignore
 use msdfgen_lib; // forces linking with msdfgen library
 use std::fs::File;
 use notosans::REGULAR_TTF as FONT;
@@ -93,10 +93,16 @@ pub use self::correct::*;
 pub use self::render::*;
 pub use self::interop::*;
 
+// Run via: cargo test --features "png,ttf-parser"
+// or: cargo test --features "all" etc.
 #[cfg(test)]
+#[allow(dead_code)]
 mod test {
     use std::fs::File;
+    #[cfg(feature = "ttf-parser")]
     use ttf_parser::Font;
+    #[cfg(feature = "freetype-rs")]
+    use freetype as freetype_rs;
     use all_asserts::assert_lt;
 
     use notosans::REGULAR_TTF;
@@ -104,7 +110,9 @@ mod test {
 
     use crate::{FontExt, Bitmap, Range, Gray, FillRule, EDGE_THRESHOLD, OVERLAP_SUPPORT};
 
-    fn test_font_char(name: &str, font: &[u8], chr: char, width: u32, height: u32, expected_error: f64) {
+    #[cfg(feature = "ttf-parser")]
+    #[cfg(feature = "png")]
+    fn test_font_char_ttf_parser(name: &str, font: &[u8], chr: char, width: u32, height: u32, expected_error: f64) {
         let font = Font::from_data(font, 0).unwrap();
         let glyph = font.glyph_index(chr).unwrap();
         let mut shape = font.glyph_shape(glyph).unwrap();
@@ -134,15 +142,74 @@ mod test {
 
         bitmap.flip_y();
 
-        let mut output = File::create(&format!("{}-msdf.png", name)).unwrap();
+        let mut output = File::create(&format!("ttf-parser-{}-msdf.png", name)).unwrap();
         bitmap.write_png(&mut output).unwrap();
 
         let mut preview = Bitmap::<Gray<f32>>::new(width * 10, height * 10);
 
         bitmap.render(&mut preview, Default::default());
 
-        let mut output = File::create(&format!("{}-preview.png", name)).unwrap();
+        let mut output = File::create(&format!("ttf-parser-{}-preview.png", name)).unwrap();
         preview.write_png(&mut output).unwrap();
+    }
+
+    #[cfg(feature = "freetype-rs")]
+    #[cfg(feature = "png")]
+    fn test_font_char_freetype_rs(name: &str, font: &[u8], chr: char, width: u32, height: u32, expected_error: f64) -> freetype_rs::FtResult<()> {
+
+        let library = freetype_rs::Library::init()?;
+        let face = library.new_memory_face(font.to_vec(), 0)?;
+        face.set_pixel_sizes(width, height)?;
+        let glyph_index = face.get_char_index(chr as usize);
+        let mut shape = face.glyph_shape(glyph_index).unwrap();
+
+        if !shape.validate() {
+            panic!("Invalid shape");
+        }
+        shape.normalize();
+
+        let bounds = shape.get_bounds();
+
+        let mut bitmap = Bitmap::new(width, height);
+
+        println!("bounds: {:?}", bounds);
+
+        shape.edge_coloring_simple(3.0, 0);
+
+        let framing = bounds.autoframe(width, height, Range::Px(4.0), None).unwrap();
+
+        println!("framing: {:?}", framing);
+
+        shape.generate_msdf(&mut bitmap, &framing, EDGE_THRESHOLD, OVERLAP_SUPPORT);
+        shape.correct_sign(&mut bitmap, &framing, FillRule::default());
+        let error = shape.estimate_error(&mut bitmap, &framing, 4, FillRule::default());
+
+        assert_lt!(error, expected_error);
+
+        bitmap.flip_y();
+
+        let mut output = File::create(&format!("freetype-{}-msdf.png", name)).unwrap();
+        bitmap.write_png(&mut output).unwrap();
+
+        let mut preview = Bitmap::<Gray<f32>>::new(width * 10, height * 10);
+
+        bitmap.render(&mut preview, Default::default());
+
+        let mut output = File::create(&format!("freetype-{}-preview.png", name)).unwrap();
+        preview.write_png(&mut output).unwrap();
+
+        Ok(())
+    }
+
+    fn test_font_char(name: &str, font: &[u8], chr: char, width: u32, height: u32, expected_error: f64) {
+
+        #[cfg(feature = "ttf-parser")]
+        #[cfg(feature = "png")]
+        test_font_char_ttf_parser(name, font, chr, width, height, expected_error);
+
+        #[cfg(feature = "freetype-rs")]
+        #[cfg(feature = "png")]
+        test_font_char_freetype_rs(name, font, chr, width, height, expected_error).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
# Provides

This pull request provides a couple of things. You're free to pick and choose what changes to bring in but I believe they're all justified.

* Fix for unit tests failing when features are turned off (the default state). In addition to making the default feature set 'all', I turned off tests when the relevant features are missing. That code produces a lot of warnings when the relevant feature is turned off so I quietened those in the test as well. We had discussed this in issue #2 .
* Added a test for using the `freetype-rs` backend which also serves as some example code.
* Fixed an issue with the extension to the `freetype-rs` backend `glyph_shape` method, which was taking a `char` as a code. I believe this is incorrect as it does not match the behavior of the `ttf-parser` backend, which takes glyph indices. Additionally, it's easy for clients to independently translate chars to glyph indicies (see the example code), but it's impossible to do the reverse (glyph->char). Thus I believe the change is correct. It might break some clients, so version would have to have a major bump.
* Bumped `freetype-rs` to the latest value. Strictly for selfish reasons.