### PR TITLE
Use the same version of `ttf-parser` as is used by `rustybuzz`

### DIFF
--- a/msdfgen/Cargo.toml
+++ b/msdfgen/Cargo.toml
@@ -27,7 +27,7 @@ version = "0.1.0"
 path = "../msdfgen-sys"
 
 [dependencies.ttf-parser]
-version = "^0.4"
+version = "^0.12.3"
 optional = true
 
 [dependencies.font]

--- a/msdfgen/src/interop/ttf_parser.rs
+++ b/msdfgen/src/interop/ttf_parser.rs
@@ -83,7 +83,7 @@ impl ttf_parser::OutlineBuilder for ShapeBuilder {
     }
 }
 
-impl<'a> FontExt for ttf_parser::Font<'a> {
+impl<'a> FontExt for ttf_parser::Face<'a> {
     type Glyph = ttf_parser::GlyphId;
 
     fn glyph_shape(&self, glyph: Self::Glyph) -> Option<Shape> {


### PR DESCRIPTION
I wanted to use `msdfgen-rs` in combination with the `rustybuzz` crate, but I couldn't because `msdfgen-rs` used an old version of the `ttf-parser` crate. This PR updates to a newer version of `ttf-parser`. The only code change required was to change one usage of `ttf_parser::Font` to `ttf_parser::Face`.
