### PR TITLE
Implement Send for Bitmap

### DIFF
--- a/msdfgen/src/bitmap.rs
+++ b/msdfgen/src/bitmap.rs
@@ -25,6 +25,8 @@ pub struct Bitmap<T> {
     height: u32,
 }
 
+unsafe impl<T> Send for Bitmap<T> {}
+
 impl<T> Bitmap<T> {
     /// Create new bitmap with specified size
     pub fn new(width: u32, height: u32) -> Self {


### PR DESCRIPTION
I wanted to distribute some of the rendering work to another thread, but I was unable to do so because `Bitmap` doesn't implement `Send`. `Bitmap` appears to manually wrap a `Vec` for FFI use. The current code appears to do everything necessary for `Send` to work, so this PR adds `unsafe impl Send`.