### PR TITLE
Fix bitmap safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ status = "passively-maintained"
 version = "0.2.1"
 path = "sys"
 
+[dependencies.bytemuck]
+version = "1"
+
 [dependencies.ttf-parser]
 version = "0.19"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ path = "sys"
 
 [dependencies.bytemuck]
 version = "1"
+features = ["extern_crate_alloc"]
 
 [dependencies.ttf-parser]
 version = "0.19"

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -30,7 +30,7 @@ pub struct Bitmap<T> {
     height: u32,
 }
 
-unsafe impl<T> Send for Bitmap<T> {}
+unsafe impl<T: Send> Send for Bitmap<T> {}
 
 impl<T> AsRef<Bitmap<T>> for Bitmap<T> {
     fn as_ref(&self) -> &Bitmap<T> {

--- a/src/bitmap/gray.rs
+++ b/src/bitmap/gray.rs
@@ -1,3 +1,5 @@
+use bytemuck::{Pod, Zeroable};
+
 use super::Pixel;
 
 /// Gray color
@@ -6,6 +8,9 @@ use super::Pixel;
 pub struct Gray<T> {
     pub v: T,
 }
+
+unsafe impl<T: Zeroable> Zeroable for Gray<T> {}
+unsafe impl<T: Pod> Pod for Gray<T> {}
 
 impl<T> Gray<T> {
     pub fn new(v: T) -> Self {

--- a/src/bitmap/png.rs
+++ b/src/bitmap/png.rs
@@ -1,8 +1,10 @@
+use bytemuck::Pod;
+
 use super::{Bitmap, Gray, Rgb, Rgba};
 use std::io::{Read, Write};
 
 pub trait PngColorType {
-    type PngPixelType;
+    type PngPixelType: Pod;
     const PNG_COLOR_TYPE: png::ColorType;
 }
 
@@ -42,7 +44,7 @@ where
 
 impl<T> Bitmap<T>
 where
-    T: PngColorType,
+    T: PngColorType + Pod,
     T: From<<T as PngColorType>::PngPixelType>,
     T::PngPixelType: Copy,
 {

--- a/src/bitmap/rgb.rs
+++ b/src/bitmap/rgb.rs
@@ -1,3 +1,5 @@
+use bytemuck::{Pod, Zeroable};
+
 use super::Pixel;
 
 /// Rgb color
@@ -8,6 +10,9 @@ pub struct Rgb<T> {
     pub g: T,
     pub b: T,
 }
+
+unsafe impl<T: Zeroable> Zeroable for Rgb<T> {}
+unsafe impl<T: Pod> Pod for Rgb<T> {}
 
 impl<T> Rgb<T> {
     pub fn new(r: T, g: T, b: T) -> Self {

--- a/src/bitmap/rgba.rs
+++ b/src/bitmap/rgba.rs
@@ -1,3 +1,5 @@
+use bytemuck::{Pod, Zeroable};
+
 use super::Pixel;
 
 /// RGB color
@@ -9,6 +11,9 @@ pub struct Rgba<T> {
     pub b: T,
     pub a: T,
 }
+
+unsafe impl<T: Zeroable> Zeroable for Rgba<T> {}
+unsafe impl<T: Pod> Pod for Rgba<T> {}
 
 impl<T> Rgba<T> {
     pub fn new(r: T, g: T, b: T, a: T) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use vector::*;
 #[allow(unused_variables)]
 mod test {
     use all_asserts::assert_lt;
+    use bytemuck::Pod;
     #[cfg(feature = "freetype-rs")]
     use freetype as freetype_rs;
     use std::fs::File;
@@ -58,7 +59,7 @@ mod test {
     #[cfg(feature = "png")]
     fn save_bitmap_and_preview<T>(pfx: &str, name: &str, sfx: &str, bitmap: &Bitmap<T>)
     where
-        T: PngColorType + Copy,
+        T: PngColorType + Copy + Pod,
         T::PngPixelType: From<T>,
         Gray<f32>: RenderTarget<T>,
     {


### PR DESCRIPTION
- Require `T: Pod` for `Bitmap::new` and `Bitmap::convert`.
- `impl Send for Bitmap` only if `T: Send`.
- Use `Box<[T]>` for allocation instead of `Vec<T>`.

This is a breaking change, and I don't think there is a non-breaking way to make `Bitmap` safe. Although most users should not notice this.

Fixes #18